### PR TITLE
feat: Add config for max contribution

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -15,6 +15,7 @@ import {
 import { formatMoney, formatPercentage } from "./formatting";
 import { Percentage } from "./Percentage";
 import { DatePicker } from "@mui/x-date-pickers";
+import { getMaxContribution } from "./constants";
 
 export default function Form() {
   // Form fields
@@ -29,7 +30,7 @@ export default function Form() {
   >(0);
   const [targetContribution, setTargetContribution] = React.useState<
     number | undefined
-  >(22500);
+  >(getMaxContribution());
 
   // Calculated fields
   const paycheckAmount = getPaycheckAmount(annualSalary, paycheckFrequency);
@@ -155,7 +156,7 @@ export default function Form() {
                 <InputAdornment position="start">$</InputAdornment>
               ),
             }}
-            helperText="Note: The annual maximum for 2023 is $22,500."
+            helperText={`Note: The annual maximum for ${new Date().getFullYear()} is $${getMaxContribution()}.`}
           />
         </Grid>
         <Grid item xs={12} md={6}>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,11 @@
+export function getMaxContribution() {
+  const year = new Date().getFullYear();
+
+  if (year === 2023) {
+    return 22500;
+  } else if (year === 2024) {
+    return 23000;
+  }
+
+  return 23000;
+}


### PR DESCRIPTION
- Adds a simple function that gets the max contribution for the current year. This allows the next year's max to be added during the current year, so that it is accurate as soon as the new year starts.
- Updated to show new $23,000 max for 2024